### PR TITLE
Update of hardware mw_source_smbv to handle list mode

### DIFF
--- a/hardware/microwave/mw_source_smbv.py
+++ b/hardware/microwave/mw_source_smbv.py
@@ -194,6 +194,10 @@ class MicrowaveSmbv(Base, MicrowaveInterface):
             stop = float(self._connection.query(':FREQ:STOP?'))
             step = float(self._connection.query(':SWE:STEP?'))
             return_val = [start+step, stop, step]
+        elif 'list' in mode: 
+            freq_str = self._connection.query(':LIST:FREQ?')
+            freq_list = freq_str.split(',')
+            return_val = np.array([float(f) for f in freq_list])
         return return_val
 
     def cw_on(self):

--- a/hardware/microwave/mw_source_smbv.py
+++ b/hardware/microwave/mw_source_smbv.py
@@ -332,7 +332,7 @@ class MicrowaveSmbv(Base, MicrowaveInterface):
 
         @return int: error code (0:OK, -1:error)
         """
-        self.log.error('List mode not available for this microwave hardware!')
+        self._command_wait(':LIST:RES')
         return -1
 
     def sweep_on(self):

--- a/hardware/microwave/mw_source_smbv.py
+++ b/hardware/microwave/mw_source_smbv.py
@@ -161,10 +161,21 @@ class MicrowaveSmbv(Base, MicrowaveInterface):
         """
         Gets the microwave output power.
 
-        @return float: the power set at the device in dBm
+        @return float, list: the power or the list of powers set at the device in dBm
         """
+        mode, is_running = self.get_status()
         # This case works for cw AND sweep mode
-        return float(self._connection.query(':POW?'))
+        if ('cw' in mode) or ('sweep' in mode):
+            rep = float(self._connection.query(':POW?'))
+        # for the list mode
+        elif 'list' in mode:
+            pow_list =  self._connection.query('LIST:POW?')
+            pow_list = pow_list.split(",")
+            rep = np.array([float(x) for x in pow_list])
+            # if there is a single value in the list, we send a single value
+            if rep.all() == rep[0]:
+                rep = rep[0]
+        return rep
 
     def get_frequency(self):
         """


### PR DESCRIPTION
# Update of hardware mw_source_smbv to handle list mode

## Description
I filled the list handling functions which were returning error saying that list mode is not supported, and added is the list mode case in the functions which set the frequency and power.

## Motivation and Context
The device is actually capable to do it, so I added the functionality which is already available for other microwave sources.

## How Has This Been Tested?
In use in our lab for several months, but the get_frequency and get_power functions might need a further test because we hardly ever use them.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [X] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
