### PR TITLE
Modification of the activation config combobox to allow searching in the list

### DIFF
--- a/gui/pulsed/pulsed_maingui.py
+++ b/gui/pulsed/pulsed_maingui.py
@@ -314,7 +314,8 @@ class PulsedMeasurementGui(GUIBase):
         # Connect signals used in pulse generator settings dialog
         self._pgs.accepted.connect(self.apply_generator_settings)
         self._pgs.rejected.connect(self.keep_former_generator_settings)
-        self._pgs.buttonBox.button(QtWidgets.QDialogButtonBox.Apply).clicked.connect(self.apply_generator_settings)
+        self._pgs.buttonBox.button(QtWidgets.QDialogButtonBox.Apply).clicked.connect(
+            self.apply_generator_settings)
         self._pgs.pg_benchmark.clicked.connect(self.run_pg_benchmark)
 
         # Connect signals used in fit settings dialog
@@ -967,8 +968,19 @@ class PulsedMeasurementGui(GUIBase):
         pg_constr = self.pulsedmasterlogic().pulse_generator_constraints
         self._pgs.gen_sample_freq_DSpinBox.setMinimum(pg_constr.sample_rate.min)
         self._pgs.gen_sample_freq_DSpinBox.setMaximum(pg_constr.sample_rate.max)
+        
         self._pgs.gen_activation_config_ComboBox.clear()
         self._pgs.gen_activation_config_ComboBox.addItems(list(pg_constr.activation_config.keys()))
+        # when the activation config list becomes large, we need a way to search inside rather
+        # than scrolling, so we use a completer. Completers only work for editable combo boxes.
+        # QComboBox.NoInsert prevents insertion of the search text
+        self._pgs.gen_activation_config_ComboBox.setEditable(True)
+        self._pgs.gen_activation_config_ComboBox.setInsertPolicy(QtWidgets.QComboBox.NoInsert)
+
+        # Change completion mode of the default completer from InlineCompletion to PopupCompletion
+        self._pgs.gen_activation_config_ComboBox.completer().setCompletionMode(
+            QtWidgets.QCompleter.PopupCompletion)
+
         for label, widget1, widget2 in self._analog_chnl_setting_widgets.values():
             widget1.setRange(pg_constr.a_ch_amplitude.min, pg_constr.a_ch_amplitude.max)
             widget2.setRange(pg_constr.a_ch_offset.min, pg_constr.a_ch_offset.max)


### PR DESCRIPTION
# Allow searching of pulser activation config in the list 

## Description
Added a completer to the combobox widgets showing the list of activation configs

## Motivation and Context
For AWGs with several analog channels with each more than 2 markers, the list of configs can be huge. For ex., with the Tektronix AWG5204 with 4 channels with 4 markers each, we can have a list of 1295 configs to cover every possibility, you cannot scroll through that. We clearly do not need all of them, but this is anyway more convenient.

## How Has This Been Tested?
Brief testing on an office computer.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [x] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
