### PR TITLE
Pulseblaser switchinterface removal

### DIFF
--- a/hardware/spincore/pulse_blaster_esrpro.py
+++ b/hardware/spincore/pulse_blaster_esrpro.py
@@ -25,7 +25,6 @@ import platform
 import numpy as np
 from collections import OrderedDict
 
-from interface.switch_interface import SwitchInterface
 from interface.pulser_interface import PulserInterface
 from interface.pulser_interface import PulserConstraints
 

--- a/hardware/spincore/pulse_blaster_esrpro.py
+++ b/hardware/spincore/pulse_blaster_esrpro.py
@@ -35,7 +35,7 @@ from core.util.mutex import Mutex
 from core.util.network import netobtain
 
 
-class PulseBlasterESRPRO(Base, SwitchInterface, PulserInterface):
+class PulseBlasterESRPRO(Base, PulserInterface):
     """ Hardware class to control the PulseBlasterESR-PRO card from SpinCore.
 
     This file is compatible with the PCI version SP18A of the PulseBlasterESR.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I've removed the SwitchInterface to pulseblaster hardware.

## Motivation and Context

The _SwitchInterface_ is a mess and is not used by this hardware in practice anyway.
This change prevent qudi version errors at activation in some branches.

